### PR TITLE
Buffer metric namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,16 @@ Datadog middleware for Connect JS / Express
 
 ## Usage
 
+```
+npm install @bufferapp/connect-datadog -S
+```
+
 Add middleware immediately before your router.
 
-  app.use(require("connect-datadog")({}));
-  app.use(app.router);
+```js
+app.use(require("connect-datadog")({}));
+app.use(app.router);
+```
 
 ## Options
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ var DD = require("node-dogstatsd").StatsD;
 
 module.exports = function (options) {
   var datadog = options.dogstatsd || new DD();
-  var stat = options.stat || "node.express.router";
+  var stat = options.stat || "buffer.server";
   var tags = options.tags || [];
   var path = options.path || false;
   var base_url = options.base_url || false;

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/AppPress/node-connect-datadog.git"
+    "url": "git://github.com/bufferapp/node-connect-datadog.git"
   },
   "keywords": [
     "datadog",
     "middleware"
   ],
-  "author": "App Press",
+  "author": "Buffer",
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/connect-datadog",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "description": "Datadog middleware for Connect JS / Express",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
### Purpose
To use a default buffer namespace as per: https://paper.dropbox.com/doc/Monitoring-Spec-Web-servers-backends-feVsLQHY9RGInyhjZHu3y