### PR TITLE
StatsD Client arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,20 @@ npm install @bufferapp/connect-datadog -S
 Add middleware immediately before your router.
 
 ```js
-app.use(require("connect-datadog")({}));
-app.use(app.router);
+const connectDatadog = require("connect-datadog")
+app.use(connectDatadog({}))
+app.use(app.router)
+```
+
+## StatsD Client Arguments
+
+You can also pass arguments to the StatsD Client after your options:
+
+```js
+connectDatadog()
+app.use(connectDatadog({
+  tags: ['some:tag']
+}, 'some.hostname', 8125))
 ```
 
 ## Options
@@ -21,7 +33,7 @@ app.use(app.router);
 All options are optional.
 
 * `dogstatsd` node-dogstatsd client. `default = new (require("node-dogstatsd")).StatsD()`
-* `stat` *string* name for the stat. `default = "node.express.router"`
+* `stat` *string* name for the stat. `default = "buffer.server"`
 * `tags` *array* of tags to be added to the histogram. `default = []`
 * `sampleRate` *number* sends only a sample of data to StatsD `default: 1`
 * `path` *boolean* include path tag. `default = false`

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,16 @@
 var DD = require("node-dogstatsd").StatsD;
 
-module.exports = function (options) {
-  var datadog = options.dogstatsd || new DD();
+/**
+ * createConnectDatadogMiddleware
+ *
+ * Returns connect middleware given the options and StatsD client arguments.
+ * @param {object} options - Middleware configuration
+ * @param {...string|number|object} clientArgs - Arguments for the StatsD Client constructor
+ *                                               (host, port, socket, options)
+ * @return {function} middleware
+ */
+module.exports = function createConnectDatadogMiddleware (options, ...clientArgs) {
+  var datadog = options.dogstatsd || new DD(...clientArgs);
   var stat = options.stat || "buffer.server";
   var tags = options.tags || [];
   var path = options.path || false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/connect-datadog",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Datadog middleware for Connect JS / Express",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
### Purpose
Make it simpler to pass arguments to the StatsD Client constructor like hostname instead of having to instantiate the Client then pass that via options.