### PR TITLE
Task/reduce custom metric usage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,11 +57,7 @@ module.exports = function createConnectDatadogMiddleware (options, ...clientArgs
 
       if (response_code) {
         statTags.push("response_code:" + res.statusCode);
-        datadog.increment(stat + '.response_code.' + res.statusCode , sampleRate, statTags);
-        datadog.increment(stat + '.response_code.all', sampleRate, statTags);
       }
-
-      datadog.histogram(stat + '.response_time', (new Date() - req._startTime), sampleRate, statTags);
 
       if (statsCallback && typeof statsCallback === 'function') {
         statsCallback(datadog, stat, sampleRate, statTags, req, res);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/connect-datadog",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Datadog middleware for Connect JS / Express",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
As part of the project to reduce the use of custom metrics, this change will get rid of the custom metrics that are reported by default when using this middleware.

The intention is that services can continue to use this middleware as they currently do (since it miht be useful for some custom metrics) but the default metrics we were reporting will no longer be sent to Datadog. These metrics, based on response times and response codes should be replaceable by metrics coming from use of APM instead.

I think I've done the minimum changes possible. Will need to go through all the services that use this middleware to update the version and check how they use the callback though (as well as any other custom metrics they might use). Starting list to follow up with: https://github.com/search?q=org%3Abufferapp+connect-datadog&type=Code

@djfarrelly - are you the best bet to review this?
